### PR TITLE
[SECURITY] Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <!--自己私仓,下载jar-->
         <repository>
             <id>ymu-hosted</id>
-            <url>http://47.52.236.72:8081/repository/maven-public/</url>
+            <url>https://47.52.236.72:8081/repository/maven-public/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -41,7 +41,7 @@
         <repository>
             <id>public</id>
             <name>aliyun nexus</name>
-            <url>http://maven.aliyun.com/nexus/content/groups/public/</url>
+            <url>https://maven.aliyun.com/nexus/content/groups/public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -62,7 +62,7 @@
         <!--私服，插件-->
         <pluginRepository>
             <id>public</id>
-            <url>http://47.52.236.72:8081/repository/maven-public/</url>
+            <url>https://47.52.236.72:8081/repository/maven-public/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -77,7 +77,7 @@
         <pluginRepository>
             <id>spring-milestone</id>
             <name>Spring Milestone</name>
-            <url>http://repo.spring.io/milestone</url>
+            <url>https://repo.spring.io/milestone</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -85,7 +85,7 @@
         <pluginRepository>
             <id>spring-snapshot</id>
             <name>Spring Snapshot</name>
-            <url>http://repo.spring.io/snapshot</url>
+            <url>https://repo.spring.io/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -97,12 +97,12 @@
         <snapshotRepository>
             <id>snapshots</id>
             <name>ymu-hosted-snapshots</name>
-            <url>http://47.52.236.72:8081/repository/maven-snapshots/</url>
+            <url>https://47.52.236.72:8081/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>repository</id>
             <name>ymu-hosted-repository</name>
-            <url>http://47.52.236.72:8081/repository/maven-releases/</url>
+            <url>https://47.52.236.72:8081/repository/maven-releases/</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"A pull request already exists for JLLeitschuh:fix/JLL/use_https_to_resolve_dependencies_maven."}],"documentation_url":"https://docs.github.com/rest/reference/pulls#create-a-pull-request"}